### PR TITLE
feat: add createTodo API with unit test

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -4,19 +4,39 @@ import { AppService } from './app.service';
 
 describe('AppController', () => {
   let appController: AppController;
+  let appService: AppService;
 
   beforeEach(async () => {
-    const app: TestingModule = await Test.createTestingModule({
+    const module: TestingModule = await Test.createTestingModule({
       controllers: [AppController],
-      providers: [AppService],
+      providers: [
+        {
+          provide: AppService,
+          useValue: {
+            // Mock the createTodo method
+            createTodo: jest.fn((dto) => ({ id: 1, ...dto })),
+          },
+        },
+      ],
     }).compile();
 
-    appController = app.get<AppController>(AppController);
+    appController = module.get<AppController>(AppController);
+    appService = module.get<AppService>(AppService);
   });
 
-  describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+  describe('createTodo', () => {
+    it('should create a new todo item', () => {
+      // Sample data
+      const createTodoDto = { title: 'Test Todo', description: 'Test description' };
+
+      // Calling createTodo method
+      const result = appController.createTodo(createTodoDto);
+
+      // Ensure that the AppService.createTodo method was called with the right DTO
+      expect(appService.createTodo).toHaveBeenCalledWith(createTodoDto);
+
+      // Check that the result matches the expected outcome
+      expect(result).toEqual({ id: 1, title: 'Test Todo', description: 'Test description' });
     });
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
+import { Controller, Post, Body } from '@nestjs/common';
+import { AppService, Todo } from './app.service';
+import { CreateTodoDto } from './todos/dto/create-todo.dto';
 
-@Controller()
+@Controller('todos')
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
-  @Get()
-  getHello(): string {
-    return this.appService.getHello();
+  @Post()
+  createTodo(@Body() createTodoDto: CreateTodoDto): Todo {
+    return this.appService.createTodo(createTodoDto);
   }
+
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,8 +1,26 @@
 import { Injectable } from '@nestjs/common';
 
+export interface Todo {
+  id: number;
+  title: string;
+  description?: string;
+  completed?: boolean;
+}
+
 @Injectable()
 export class AppService {
-  getHello(): string {
-    return 'Hello World!';
+  private todos: Todo[] = [];
+  private idCounter = 1;
+
+  // Create a new todo item to database
+  createTodo(todo: Omit<Todo, 'id'>): Todo {
+    const newTodo: Todo = {
+      id: this.idCounter++, // Assign auto-incremented id
+      ...todo // rest of items
+    };
+
+    this.todos.push(newTodo); // Add the new todo to the list
+    return newTodo;
   }
+  
 }

--- a/src/todos/dto/create-todo.dto.ts
+++ b/src/todos/dto/create-todo.dto.ts
@@ -1,0 +1,8 @@
+export class CreateTodoDto {
+    readonly title: string;
+    readonly description: string;
+    readonly status?: boolean;
+}
+  
+
+  


### PR DESCRIPTION
## What does this PR do?
- Implements the createTodo API endpoint to allow users to add new todo items.
- Adds a unit test for createTodo in AppController to ensure correctness.
- Uses Jest to mock the AppService and verify controller behavior.

## How to test?
1. Run the unit test: `pnpm run test`
2. Check if all tests pass.

## Additional Notes:
- The API currently stores todos in memory (no database yet).
- Future improvement: Add persistence with a database.
