### PR TITLE
feat: add updateTodo API with unit test

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { NotFoundException } from '@nestjs/common';
 
 describe('AppController', () => {
   let appController: AppController;
@@ -21,6 +22,7 @@ describe('AppController', () => {
               { id: 4, title: 'Todo 4', description: 'Test description 4' },
             ]),
             createTodo: jest.fn((dto) => ({ id: 1, ...dto })),
+            updateTodo: jest.fn(),
           },
         },
       ],
@@ -66,4 +68,34 @@ describe('AppController', () => {
       expect(result).toEqual({ id: 1, title: 'Test Todo', description: 'Test description' });
     });
   });
+
+  describe('updateTodo', () => {
+    it('should update an existing todo and return the updated todo', () => {
+      const id = '1';
+      const updateData = { title: 'Updated Title' };
+      const updatedTodo = { id: 1, title: 'Updated Title', description: 'Existing description' };
+  
+      // Mock the updateTodo method to return our updatedTodo
+      (appService.updateTodo as jest.Mock).mockReturnValue(updatedTodo);
+  
+      const result = appController.updateTodo(id, updateData);
+  
+      expect(appService.updateTodo).toHaveBeenCalledWith(1, updateData);
+      expect(result).toEqual(updatedTodo);
+    });
+  
+    it('should throw NotFoundException if todo is not found', () => {
+      const id = '999';
+      const updateData = { title: 'Updated Title' };
+  
+      // Mock the updateTodo method to throw a NotFoundException
+      (appService.updateTodo as jest.Mock).mockImplementation(() => {
+        throw new NotFoundException(`Todo with ${id} not found!`);
+      });
+  
+      // Expect the controller to throw the same error when updateTodo is called
+      expect(() => appController.updateTodo(id, updateData)).toThrow(NotFoundException);
+      expect(appService.updateTodo).toHaveBeenCalledWith(999, updateData);
+    });
+  })
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Post, Body, Get } from '@nestjs/common';
+import { Controller, Post, Body, Get, Put, Param } from '@nestjs/common';
 import { AppService, Todo } from './app.service';
 import { CreateTodoDto } from './todos/dto/create-todo.dto';
+import { UpdateTodoDto } from './todos/dto/update-todo.dto';
 
 @Controller('todos')
 export class AppController {
@@ -14,6 +15,14 @@ export class AppController {
   @Post()
   createTodo(@Body() createTodoDto: CreateTodoDto): Todo {
     return this.appService.createTodo(createTodoDto);
+  }
+
+  @Put(':id')
+  updateTodo(
+    @Param('id') id: string,
+    @Body() updateData: UpdateTodoDto,
+  ): Todo {
+    return this.appService.updateTodo(Number(id), updateData);
   }
 
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -1,10 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
 export interface Todo {
   id: number;
   title: string;
   description?: string;
-  completed?: boolean;
+  status?: boolean;
 }
 
 @Injectable()
@@ -27,5 +27,19 @@ export class AppService {
     this.todos.push(newTodo); // Add the new todo to the list
     return newTodo;
   }
-  
+
+  // Update existing todo item
+  updateTodo(id: number, updateData: Partial<Omit<Todo, 'id'>>): Todo {
+    const index = this.todos.findIndex(todo => todo.id === id);
+
+    if(index === -1) {
+      throw new NotFoundException(`Todo with ${id} not found!`); // not found
+    }
+
+    const updatedTodo = { ...this.todos[index], ...updateData };
+
+    this.todos[index] = updatedTodo;    
+    
+    return updatedTodo;
+  }
 }

--- a/src/todos/dto/update-todo.dto.ts
+++ b/src/todos/dto/update-todo.dto.ts
@@ -1,0 +1,8 @@
+export class UpdateTodoDto {
+    readonly title?: string;
+    readonly description?: string;
+    readonly status?: boolean;
+}
+  
+
+  


### PR DESCRIPTION
## What does this PR do?
This PR implements the updateTodo functionality to allow users to update an existing todo item. The changes include an API endpoint in AppController and an update method in AppService. It also introduces unit tests to ensure both successful updates and error handling when the item is not found.

## Changes Made
- **Controller:**  
  - Added a PUT endpoint (`@Put(':id')`) to handle updating a todo.
  - The endpoint extracts the todo ID from the route and update data from the request body.
- **Service:**  
  - Implemented `updateTodo` that locates the todo in an in-memory array.
  - Merges the update data with the existing todo.
  - Throws a `NotFoundException` if the specified todo does not exist.
- **Unit Tests:**  
  - Added tests to verify that the update functionality works as expected.
  - Included a test for a successful update and another to ensure the proper exception is thrown when the todo is not found.