### PR TITLE
feat: add deleteTodo API with unit test

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -23,6 +23,7 @@ describe('AppController', () => {
             ]),
             createTodo: jest.fn((dto) => ({ id: 1, ...dto })),
             updateTodo: jest.fn(),
+            deleteTodo: jest.fn(),
           },
         },
       ],
@@ -32,6 +33,7 @@ describe('AppController', () => {
     appService = module.get<AppService>(AppService);
   });
 
+  // Unit Test for Retrieving all todo items
   describe('getAllTodos', () => {
     it('should return an array of todos', () => {
       // Define expected todos matching the mock
@@ -53,6 +55,7 @@ describe('AppController', () => {
     });
   });
 
+  // Unit Test for Create a new todo item
   describe('createTodo', () => {
     it('should create a new todo item', () => {
       // Sample data
@@ -69,6 +72,7 @@ describe('AppController', () => {
     });
   });
 
+  // Unit Test for Update todo item
   describe('updateTodo', () => {
     it('should update an existing todo and return the updated todo', () => {
       const id = '1';
@@ -98,4 +102,38 @@ describe('AppController', () => {
       expect(appService.updateTodo).toHaveBeenCalledWith(999, updateData);
     });
   })
+
+  // Unit Test for Remove one todo item
+  describe('deleteTodo', () => {
+    it('should delete a todo by id and return the removed todo', () => {
+      const id = '1';
+      const removedTodo = { id: 1, title: 'Todo 1', description: 'Test description 1' };
+  
+      // Mock the deleteTodo method to return the removed todo
+      (appService.deleteTodo as jest.Mock).mockReturnValue(removedTodo);
+  
+      // Call the controller's deleteTodo method (id is passed as string, service expects a number)
+      const result = appController.deleteTodo(id);
+  
+      // Verify that the service method was called with the correct numeric id
+      expect(appService.deleteTodo).toHaveBeenCalledWith(1);
+  
+      // Verify that the result matches the removed todo
+      expect(result).toEqual(removedTodo);
+    });
+  
+    it('should throw NotFoundException if the todo is not found', () => {
+      const id = '999';
+  
+      // Mock the deleteTodo method to throw a NotFoundException
+      (appService.deleteTodo as jest.Mock).mockImplementation(() => {
+        throw new NotFoundException(`Todo with id ${id} not found`);
+      });
+  
+      // Expect the controller's deleteTodo method to throw the exception
+      expect(() => appController.deleteTodo(id)).toThrow(NotFoundException);
+      expect(appService.deleteTodo).toHaveBeenCalledWith(999);
+    });
+  });
+  
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, Get, Put, Param } from '@nestjs/common';
+import { Controller, Post, Body, Get, Put, Param, Delete } from '@nestjs/common';
 import { AppService, Todo } from './app.service';
 import { CreateTodoDto } from './todos/dto/create-todo.dto';
 import { UpdateTodoDto } from './todos/dto/update-todo.dto';
@@ -23,6 +23,11 @@ export class AppController {
     @Body() updateData: UpdateTodoDto,
   ): Todo {
     return this.appService.updateTodo(Number(id), updateData);
+  }
+
+  @Delete(':id')
+  deleteTodo(@Param('id') id: string): Todo {
+    return this.appService.deleteTodo(Number(id));
   }
 
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -42,4 +42,17 @@ export class AppService {
     
     return updatedTodo;
   }
+
+  // Remove one todo item from database
+  deleteTodo(id: number): Todo {
+    const index = this.todos.findIndex(todo => todo.id === id);
+
+    if (index === -1) {
+      throw new NotFoundException(`Todo with id ${id} not found`);
+    }
+
+    const removed = this.todos.splice(index, 1)[0];
+    
+    return removed;
+  }
 }


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new endpoint to delete a todo item. The deleteTodo functionality has been implemented in the service layer and exposed via the controller. It includes error handling for scenarios where the specified todo item is not found.

## Changes Made
- **Controller:**
  - Added a DELETE endpoint that calls the service's deleteTodo method.
- **Service:**
  - Implemented the deleteTodo method that:
    - Finds the todo item by its ID.
    - Removes the todo from the in-memory array using splice.
    - Returns the deleted todo item.
    - Throws a NotFoundException if the todo is not found.
- **Unit Tests:**
  - Added tests to verify that:
    - A todo is correctly deleted and returned.
    - A NotFoundException is thrown when attempting to delete a non-existent todo.
