### PR TITLE
feat: add deleteAllTodos API with unit test

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -24,6 +24,7 @@ describe('AppController', () => {
             createTodo: jest.fn((dto) => ({ id: 1, ...dto })),
             updateTodo: jest.fn(),
             deleteTodo: jest.fn(),
+            deleteAllTodos: jest.fn()
           },
         },
       ],
@@ -135,5 +136,28 @@ describe('AppController', () => {
       expect(appService.deleteTodo).toHaveBeenCalledWith(999);
     });
   });
+
+  // Unit Test for Removing all items in Todo list
+  describe('deleteAllTodo', () => {
+    it('should delete all todos and return the deleted todos', () => {
+      const allTodos = [
+        { id: 1, title: 'Todo 1', description: 'Test description 1' },
+        { id: 2, title: 'Todo 2', description: 'Test description 2' },
+      ];
+  
+      // Mock the deleteAllTodos method to return the predefined todos array
+      (appService.deleteAllTodos as jest.Mock).mockReturnValue(allTodos);
+  
+      // Call the controller's deleteAllTodo method
+      const result = appController.deleteAllTodo();
+  
+      // Verify that the service method was called
+      expect(appService.deleteAllTodos).toHaveBeenCalled();
+  
+      // Verify that the controller returns the expected todos
+      expect(result).toEqual(allTodos);
+    });
+  });
+  
   
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -30,4 +30,9 @@ export class AppController {
     return this.appService.deleteTodo(Number(id));
   }
 
+  @Delete()
+  deleteAllTodo(): Todo[] {
+    return this.appService.deleteAllTodos();
+  }
+
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -55,4 +55,14 @@ export class AppService {
     
     return removed;
   }
+
+  // Remove all todo items
+  deleteAllTodos(): Todo[] {
+    const allTodos = { ...this.todos };
+
+    // Clear all existing items
+    this.todos = [];
+
+    return allTodos;
+  }
 }


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new endpoint that removes all todo items from the in-memory list. The controller exposes a DELETE endpoint that calls the service's deleteAllTodos method, which clears the current todo list and returns the removed todos.

## Changes Made
- **Controller:**
  - Added a DELETE endpoint (@Delete()) named deleteAllTodo that delegates the deletion logic to the service.
- **Service:**
  - Implemented the deleteAllTodos method which:
    - Copies all existing todos.
    - Clears the in-memory todos array.
    - Returns the deleted todos.
- **Unit Tests:**
  - Added tests for the deleteAllTodo endpoint to verify:
    - The service method is correctly called.
    - The endpoint returns the expected list of removed todos.
